### PR TITLE
disable requested authentication context

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,15 +49,15 @@ npm install apostrophe-saml
       callbackUrl: 'https://example.com/auth/saml/login/callback'
       //
       // OPTIONAL: Extra passport-saml options
-	    // Configuring saml in your environment can be tricky, and most
-	    // environments have unique aspects to them that aren't handled
-  	  // directly by this wrapper. To help with this problem, you can
-  	  // pass extra passport-saml options through the following object.
-  	  // More details about available options can be found here:
-  	  // https://github.com/bergie/passport-saml#config-parameter-details
+      // Configuring saml in your environment can be tricky, and most
+      // environments have unique aspects to them that aren't handled
+      // directly by this wrapper. To help with this problem, you can
+      // pass extra passport-saml options through the following object.
+      // More details about available options can be found here:
+      // https://github.com/bergie/passport-saml#config-parameter-details
       //
-  	  //  passportSamlOptions: {
-  	  //    disableRequestedAuthnContext: true,
+      //  passportSamlOptions: {
+      //    disableRequestedAuthnContext: true,
       //    logoutUrl: 'https://examples.com/auth/saml/SLO',
       //    forceAuthn: true 
       //  }

--- a/README.md
+++ b/README.md
@@ -47,6 +47,20 @@ npm install apostrophe-saml
       // your identity provider may result in mysterious failed logins.
       // Make sure they are on board with what this URL has been set to
       callbackUrl: 'https://example.com/auth/saml/login/callback'
+      //
+      // OPTIONAL: Extra passport-saml options
+	    // Configuring saml in your environment can be tricky, and most
+	    // environments have unique aspects to them that aren't handled
+  	  // directly by this wrapper. To help with this problem, you can
+  	  // pass extra passport-saml options through the following object.
+  	  // More details about available options can be found here:
+  	  // https://github.com/bergie/passport-saml#config-parameter-details
+      //
+  	  //  passportSamlOptions: {
+  	  //    disableRequestedAuthnContext: true,
+      //    logoutUrl: 'https://examples.com/auth/saml/SLO',
+      //    forceAuthn: true 
+      //  }
     },
     'apostrophe-login': {
       // OPTIONAL: disable regular site logins completely

--- a/index.js
+++ b/index.js
@@ -50,9 +50,10 @@ module.exports = {
       // passport-saml uses entryPoint, not identityProviderUrl
       config.entryPoint = config.identityProviderUrl;  
       config.callbackUrl = options.callbackUrl || (options.apos.options.baseUrl + '/auth/saml/login/callback');
-      // configure passport-saml to disable the default authentication context
-      config.disableRequestedAuthnContext = options.disableRequestedAuthnContext;
 
+	  //Add our extra passportSamlOptions into our config object
+	  config = self.addPassportSamlOptions(config);
+	  
       var strategy = new passportSaml.Strategy(
         config,
         self.profileCallback
@@ -87,6 +88,20 @@ module.exports = {
         return '/auth/saml/login/callback';
       }
     };
+	
+	self.addPassportSamlOptions = function(config) {
+	  //merge the base configuration options into the passportSamlOptionsObject
+	  //Note: if you have the same attribute in both objects, the base configuration option will overwrite the passportSamlOptions attribute	  {
+	  for(var attr in options.passportSamlOptions){
+		  if(attr in config){
+			  continue; //Do not overwrite existing config attributes.
+		  }
+		  config[attr]=options.passportSamlOptions[attr]; //copy the optional attribute into our config object
+	  }  
+	  
+	  return config;
+	  
+	};
 
     self.addRoutes = function() {
       self.apos.app.get(self.getLoginPath(),

--- a/index.js
+++ b/index.js
@@ -50,9 +50,8 @@ module.exports = {
       // passport-saml uses entryPoint, not identityProviderUrl
       config.entryPoint = config.identityProviderUrl;  
       config.callbackUrl = options.callbackUrl || (options.apos.options.baseUrl + '/auth/saml/login/callback');
-
-	  //Add our extra passportSamlOptions into our config object
-	  config = self.addPassportSamlOptions(config);
+      //Add our extra passportSamlOptions into our config object
+      config = self.addPassportSamlOptions(config);
 	  
       var strategy = new passportSaml.Strategy(
         config,
@@ -89,19 +88,11 @@ module.exports = {
       }
     };
 	
-	self.addPassportSamlOptions = function(config) {
-	  //merge the base configuration options into the passportSamlOptionsObject
-	  //Note: if you have the same attribute in both objects, the base configuration option will overwrite the passportSamlOptions attribute	  {
-	  for(var attr in options.passportSamlOptions){
-		  if(attr in config){
-			  continue; //Do not overwrite existing config attributes.
-		  }
-		  config[attr]=options.passportSamlOptions[attr]; //copy the optional attribute into our config object
-	  }  
-	  
-	  return config;
-	  
-	};
+    self.addPassportSamlOptions = function(config) {
+      //merge the base configuration options into the passportSamlOptionsObject
+      //Note: if you have the same attribute in both objects, the base configuration option will overwrite the passportSamlOptions attribute	  {
+      return Object.assign({}, options.passportSamlOptions, config);
+    };
 
     self.addRoutes = function() {
       self.apos.app.get(self.getLoginPath(),

--- a/index.js
+++ b/index.js
@@ -50,6 +50,8 @@ module.exports = {
       // passport-saml uses entryPoint, not identityProviderUrl
       config.entryPoint = config.identityProviderUrl;  
       config.callbackUrl = options.callbackUrl || (options.apos.options.baseUrl + '/auth/saml/login/callback');
+      // configure passport-saml to disable the default authentication context
+      config.disableRequestedAuthnContext = options.disableRequestedAuthnContext;
 
       var strategy = new passportSaml.Strategy(
         config,


### PR DESCRIPTION
Passport saml sets a default authentication context of 'PasswordProtectedTransport'. There is some sort of bug with passport saml when trying to use this AuthnContext from a private internal network and authenticate with an external IDP. The proposed change her allows the developer to easily disable this authentication context and let the IDP determine the method of authentication. 

With this change, simply add the following line to your configuration for apostrophe-saml inside of your Apostrophe app.js:

disableRequestedAuthnContext: true

Example:

'apostrophe-saml': {
  issuer: 'mysite.com',
  callbackUrl: 'mysite.com/callback',
  disableRequestedAuthnContext: true
}



More details can be found here: https&#58;//github.com/bergie/<i></i>passport-saml/issues/226

@boutell